### PR TITLE
APN: Add APNs for Rakuten Mobile(MNO)

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -2900,6 +2900,7 @@
   <apn carrier="楽天モバイル" mcc="440" mnc="10" apn="rmobile.jp" user="rm" password="0000" authtype="3" type="default,supl" />
   <apn carrier="楽天モバイル" mcc="440" mnc="10" apn="vdm.jp" user="rakuten@vdm" password="vrkt" authtype="3" type="default,supl" />
   <apn carrier="IMS" mcc="440" mnc="10" apn="ims" type="ims" protocol="IPV6" />
+  <apn carrier="楽天モバイル" mcc="440" mnc="11" apn="rakuten.jp" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Y!mobile" mcc="440" mnc="20" apn="plus.acs.jp" user="ym" password="ym" mmsc="http://mms-s" mmsproxy="andmms.plusacs.ne.jp" mmsport="8080" authtype="2" type="default,supl,mms" />
   <apn carrier="andoworld" mcc="440" mnc="20" apn="andoworld.softbank.ne.jp" mmsc="http://mms/" mmsproxy="andmms.softbank.ne.jp" mmsport="8080" authtype="2" type="default,supl,mms" />
   <apn carrier="fourgsmartphone" mcc="440" mnc="20" apn="fourgsmartphone" user="" password="" mmsc="http://mms/" mmsproxy="andmms.softbank.ne.jp" mmsport="8080" authtype="2" type="default,supl,mms" />


### PR DESCRIPTION
MNO版楽天モバイルのAPNを追加します。

APNタイプはいつもの如くDUNはエラーになるので入力していません。
認証タイプは無入力で良さそうなので未設定です。
PDPタイプは設定項目としてなさそうなので設定していません（apns_conf.xmlにも入力されているAPNは一つもありませんでした）

- 参考ページ: [APN情報を確認したい | よくあるご質問 | 楽天モバイル](https://network.mobile.rakuten.co.jp/faq/detail/00001495/)

しかしスクリーンショットで設定を乗せてない当たり、格安SIMとしてはかなり不親切なような・・・